### PR TITLE
Patch true fullscreen

### DIFF
--- a/dmxwebcam.c
+++ b/dmxwebcam.c
@@ -273,7 +273,7 @@ main(
         { "help", no_argument, NULL, 'h' },
         { "pidfile", required_argument, NULL, 'p' },
         { "sample", required_argument, NULL, 's' },
-        { "stretch", required_argument, NULL, 'r' },
+        { "stretch", no_argument, NULL, 'S' },
         { "videodevice", required_argument, NULL, 'v' },
         { "width", required_argument, NULL, 'W' },
         { NULL, no_argument, NULL, 0 }
@@ -335,7 +335,7 @@ main(
 
             break;
 
-	case 'r':
+        case 'S':
 
             stretch = true;
 

--- a/dmxwebcam.c
+++ b/dmxwebcam.c
@@ -96,6 +96,7 @@ printUsage(
     fprintf(fp, "    --fps <fps> - set desired frames per second");
     fprintf(fp, " (default %d frames per second)\n", DEFAULT_FPS);
     fprintf(fp, "    --fullscreen - show full screen\n");
+    fprintf(fp, "    --stretch - show full screen and stretch\n");
     fprintf(fp, "    --pidfile <pidfile> - create and lock PID file");
     fprintf(fp, " (if being run as a daemon)\n");
     fprintf(fp, "    --sample <value> - only display every value frame)\n");
@@ -253,6 +254,8 @@ main(
 
     bool fullscreen = false;
 
+    bool stretch = false;
+
     const char *vdevice = DEFAULT_VIDEO_DEVICE;
 
     uint32_t displayNumber = DEFAULT_DISPLAY_NUMBER;
@@ -270,6 +273,7 @@ main(
         { "help", no_argument, NULL, 'h' },
         { "pidfile", required_argument, NULL, 'p' },
         { "sample", required_argument, NULL, 's' },
+        { "stretch", required_argument, NULL, 'r' },
         { "videodevice", required_argument, NULL, 'v' },
         { "width", required_argument, NULL, 'W' },
         { NULL, no_argument, NULL, 0 }
@@ -328,6 +332,12 @@ main(
             {
                 sample = 1;
             }
+
+            break;
+
+	case 'r':
+
+            stretch = true;
 
             break;
 
@@ -496,6 +506,11 @@ main(
                                              display,
                                              update);
     }
+    else if (stretch)
+        addElementYUV420ImageLayerStretch(&imageLayer,
+                                          &info,
+                                          display,
+                                          update);
     else
     {
         addElementYUV420ImageLayerCentered(&imageLayer,

--- a/yuv420ImageLayer.c
+++ b/yuv420ImageLayer.c
@@ -181,6 +181,30 @@ addElementYUV420ImageLayerFullScreen(
 //-------------------------------------------------------------------------
 
 void
+addElementYUV420ImageLayerStretch(
+    YUV420_IMAGE_LAYER_T *il,
+    DISPMANX_MODEINFO_T *info,
+    DISPMANX_DISPLAY_HANDLE_T display,
+    DISPMANX_UPDATE_HANDLE_T update)
+{
+    vc_dispmanx_rect_set(&(il->srcRect),
+                         0 << 16,
+                         0 << 16,
+                         il->image.width << 16,
+                         il->image.height << 16);
+
+    vc_dispmanx_rect_set(&(il->dstRect),
+		         0,
+			 0,
+                         info->width,
+                         info->height);
+
+    addElementYUV420ImageLayer(il, display, update);
+}
+
+//-------------------------------------------------------------------------
+
+void
 addElementYUV420ImageLayer(
     YUV420_IMAGE_LAYER_T *il,
     DISPMANX_DISPLAY_HANDLE_T display,

--- a/yuv420ImageLayer.h
+++ b/yuv420ImageLayer.h
@@ -85,6 +85,13 @@ addElementYUV420ImageLayerFullScreen(
     DISPMANX_UPDATE_HANDLE_T update);
 
 void
+addElementYUV420ImageLayerStretch(
+    YUV420_IMAGE_LAYER_T *il,
+    DISPMANX_MODEINFO_T *info,
+    DISPMANX_DISPLAY_HANDLE_T display,
+    DISPMANX_UPDATE_HANDLE_T update);
+
+void
 addElementYUV420ImageLayer(
     YUV420_IMAGE_LAYER_T *il,
     DISPMANX_DISPLAY_HANDLE_T display,


### PR DESCRIPTION
In #5 I have pointed out the problems I have with capturing at 720x576 with scaling I don't have this issues. The current fullscreen option blacks out the background, while instead I would like to have a stretched output.